### PR TITLE
Update gatsby-node.js

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -177,7 +177,9 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       reporter.info(`directory deleted at ${path}`)
     }
     const node = getNode(createNodeId(path))
-    deleteNode({ node })
+    if (node) {
+      deleteNode({ node })
+    }
   })
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Deleting directory make gatsby crash. When working with markdownfiles and deleting a directory the developer server will crash. The same check that is for files should also be on directories, otherwise it might try to delete a directory that does not exist.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
